### PR TITLE
Add request and processing logging

### DIFF
--- a/src/main/java/com/rahul/travel/BalanceController.java
+++ b/src/main/java/com/rahul/travel/BalanceController.java
@@ -6,9 +6,11 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
+import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequestMapping("/balances")
+@Slf4j
 public class BalanceController {
   private final TripRepository trips;
   private final ExpenseRepository expenses;
@@ -22,6 +24,7 @@ public class BalanceController {
 
   @GetMapping("/{tripId}")
   public List<GroupBalanceDTO> compute(@PathVariable String tripId) {
+    log.info("Received request to compute balances for trip {}", tripId);
     Trip t = trips.findById(tripId)
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Trip not found"));
     List<Expense> ex = expenses.findByTripIdOrderByDateDesc(tripId);

--- a/src/main/java/com/rahul/travel/ExpenseController.java
+++ b/src/main/java/com/rahul/travel/ExpenseController.java
@@ -5,9 +5,11 @@ import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Set;
 import org.springframework.web.bind.annotation.*;
+import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequestMapping("/expenses")
+@Slf4j
 public class ExpenseController {
   private final ExpenseRepository expenses;
 
@@ -17,6 +19,7 @@ public class ExpenseController {
 
   @PostMapping
   public ExpenseDTO create(@RequestBody @Valid ExpenseDTO dto) {
+    log.info("Received request to create expense for trip {}", dto.tripId());
     Expense e = new Expense();
     e.setTripId(dto.tripId());
     e.setTitle(dto.title());
@@ -31,6 +34,7 @@ public class ExpenseController {
 
   @GetMapping("/{tripId}")
   public List<ExpenseDTO> byTrip(@PathVariable String tripId) {
+    log.info("Received request to list expenses for trip {}", tripId);
     return expenses.findByTripIdOrderByDateDesc(tripId).stream().map(this::toDTO).toList();
   }
 

--- a/src/main/java/com/rahul/travel/HealthController.java
+++ b/src/main/java/com/rahul/travel/HealthController.java
@@ -2,11 +2,14 @@ package com.rahul.travel;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import lombok.extern.slf4j.Slf4j;
 
 @RestController
+@Slf4j
 public class HealthController {
   @GetMapping("/health")
   public String health() {
+    log.info("Health endpoint accessed");
     return "OK";
   }
 }

--- a/src/main/java/com/rahul/travel/ItineraryController.java
+++ b/src/main/java/com/rahul/travel/ItineraryController.java
@@ -3,9 +3,11 @@ package com.rahul.travel;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.springframework.web.bind.annotation.*;
+import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequestMapping("/itinerary")
+@Slf4j
 public class ItineraryController {
   public record ItineraryRequest(String destination, int days, String budgetLevel, List<String> interests) {}
   public record DayPlan(int day, List<String> items) {}
@@ -13,6 +15,7 @@ public class ItineraryController {
 
   @PostMapping
   public ItineraryResponse generate(@RequestBody ItineraryRequest req) {
+    log.info("Generating itinerary for {} over {} days", req.destination(), req.days());
     List<DayPlan> plan = IntStream.rangeClosed(1, Math.max(1, req.days()))
         .mapToObj(d -> new DayPlan(d, List.of(
             "Morning: Coffee & walking tour",

--- a/src/main/java/com/rahul/travel/TripController.java
+++ b/src/main/java/com/rahul/travel/TripController.java
@@ -6,10 +6,12 @@ import java.util.List;
 import java.util.Set;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequestMapping("/trips")
 @Validated
+@Slf4j
 public class TripController {
   private final TripRepository trips;
 
@@ -19,6 +21,7 @@ public class TripController {
 
   @PostMapping
   public TripDTO create(@RequestBody @Valid TripDTO dto) {
+    log.info("Received request to create trip {}", dto.name());
     Trip t = new Trip();
     t.setName(dto.name());
     t.setStartDate(dto.startDate());
@@ -32,6 +35,7 @@ public class TripController {
 
   @GetMapping
   public List<TripDTO> all() {
+    log.info("Received request to list all trips");
     return trips.findAll().stream().map(this::toDTO).toList();
   }
 

--- a/src/main/java/com/rahul/travel/service/SplitService.java
+++ b/src/main/java/com/rahul/travel/service/SplitService.java
@@ -6,10 +6,13 @@ import com.rahul.travel.dto.GroupBalanceDTO;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
+@Slf4j
 public class SplitService {
   public List<GroupBalanceDTO> computeBalances(Trip trip, List<Expense> expenses) {
+    log.info("Processing {} expenses for trip {}", expenses.size(), trip.getId());
     Map<String, Double> net = trip.getParticipants().stream()
         .collect(Collectors.toMap(p -> p, p -> 0.0));
 
@@ -46,6 +49,7 @@ public class SplitService {
       if (dRem < 0) debtors.add(new Node(d.name(), dRem));
       if (cRem > 0) creditors.add(new Node(c.name(), cRem));
     }
+    log.info("Computed {} settlements for trip {}", settlements.size(), trip.getId());
     return settlements;
   }
 


### PR DESCRIPTION
## Summary
- add SLF4J logging to controllers to trace incoming requests
- log balance computations in SplitService for visibility into processing

## Testing
- `mvn -q -ntp test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_689d2923086483279f4e5ef76c2f3868