### PR TITLE
Fix budget creation and Apple token verification

### DIFF
--- a/src/main/java/com/axora/travel/security/GoogleTokenVerifier.java
+++ b/src/main/java/com/axora/travel/security/GoogleTokenVerifier.java
@@ -27,7 +27,12 @@ public class GoogleTokenVerifier {
   public GoogleIdToken.Payload verify(String idToken) throws Exception {
     GoogleIdToken token = verifier.verify(idToken);
     if (token == null) throw new IllegalArgumentException("Invalid Google ID token");
-    return token.getPayload();
+    var p = token.getPayload();
+    if (p.getEmail() == null) throw new IllegalArgumentException("Google token missing email");
+    if (!Boolean.TRUE.equals(p.getEmailVerified())) {
+      throw new IllegalArgumentException("Google email not verified");
+    }
+    return p;
   }
 }
 // --- GoogleTokenVerifier end ---


### PR DESCRIPTION
## Summary
- Build budgets via no-args constructor and setters; add internal CreateReq record and trip membership guard
- Replace Apple token verifier to use RS256 and RemoteJWKSet
- Harden Google token verification by checking email and verification flag

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.4 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a6bc279fd48327bb65054a3d2c9992